### PR TITLE
Add Ruby 2.1.2 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ script: 'bundle exec rake'
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1.2
   - ruby-head
-  - rbx-19mode
   - jruby-19mode
   - jruby-head
 


### PR DESCRIPTION
Also removes `rbx-19mode` which Travis no longer supports.