### PR TITLE
Updated session store expires_in example to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ MyApplication::Application.config.session_store :redis_store, servers: { :host =
                                                                          :port => 6379,
                                                                          :db => 0,
                                                                          :password => "mysecret",
-                                                                         :namespace => "cache",
-                                                                         :expires_in => 90.minutes }
+                                                                         :namespace => "session"
+                                                                       },
+                                                                       :expires_in => 90.minutes
 ```
 
 And if you would like to use Redis as a rack-cache backend for HTTP caching:


### PR DESCRIPTION
Current readme's session expire setting doesn't work, redis ttl always return -1.
Expires_in set after servers setting.
After expire setting changed, I confirmed redis ttl countdown.
So I updated readme's session expire setting.
Please check this.

Same issue found stack over flow.
[ruby on rails - redis_store sessions not expiring. <Fixed> - Stack Overflow](http://stackoverflow.com/questions/20907247/redis-store-sessions-not-expiring-fixed)

I conrirmed Ruby2.1.4, Rails 4.2.0 environments.