### PR TITLE
Drop support for Ruby v1.9.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,11 @@ language: ruby
 before_install: gem install bundler
 script: 'bundle exec rake'
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2
   - 2.3.0
   - ruby-head
-  - jruby-19mode
   - jruby-head
 
 matrix:


### PR DESCRIPTION
There are issues with CI actually grabbing these Ruby versions, and
they're EOL from the Ruby project perspective, so I think it's safe to
drop support for both jruby 1.9 mode and MRI 1.9.3.