### PR TITLE
Allow redis-store 1.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 gemspec
 
 if ::File.directory?(gem_path = "../redis-store")
-  gem "redis-store", "~> 1.2.0.pre", path: gem_path
+  gem "redis-store", [">= 1.2.0", "< 1.4"], path: gem_path
 end
 
 if ::File.directory?(gem_path = "../redis-rack")

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ config.session_store :redis_store, {
 gem install bundler
 git clone git://github.com/redis-store/redis-rails.git
 cd redis-rails
-bundle install
-bundle exec rake
+RAILS_VERSION=5.0.1 bundle install
+RAILS_VERSION=5.0.1 bundle exec rake
 ```
 
 If you are on **Snow Leopard** you have to run `env ARCHFLAGS="-arch x86_64" bundle exec rake`

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ MyApplication::Application.config.session_store :redis_store, servers: "redis://
 You can also provide a hash instead of a URL
 
 ```ruby
-config.cache_store = :redis_store, { 
+config.cache_store = :redis_store, {
   host: "localhost",
   port: 6379,
   db: 0,
@@ -112,8 +112,8 @@ If you are on **Snow Leopard** you have to run `env ARCHFLAGS="-arch x86_64" bun
 
 ## Status
 
-[![Gem Version](https://badge.fury.io/rb/redis-rails.png)](http://badge.fury.io/rb/redis-rails) 
-[![Build Status](https://secure.travis-ci.org/redis-store/redis-rails.png?branch=master)](http://travis-ci.org/redis-store/redis-rails?branch=master) 
+[![Gem Version](https://badge.fury.io/rb/redis-rails.png)](http://badge.fury.io/rb/redis-rails)
+[![Build Status](https://secure.travis-ci.org/redis-store/redis-rails.png?branch=master)](http://travis-ci.org/redis-store/redis-rails?branch=master)
 [![Code Climate](https://codeclimate.com/github/redis-store/redis-rails.png)](https://codeclimate.com/github/redis-store/redis-rails)
 
 ## Copyright

--- a/redis-rails.gemspec
+++ b/redis-rails.gemspec
@@ -19,13 +19,13 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "redis-store",         "~> 1.2.0"
+  s.add_dependency "redis-store",         [">= 1.2.0", "< 1.4"]
   s.add_dependency "redis-activesupport", "~> 5.0.0"
   s.add_dependency "redis-actionpack",    "~> 5.0.0"
 
   s.add_development_dependency "rake",     "~> 10"
   s.add_development_dependency "bundler",  "~> 1.3"
   s.add_development_dependency "mocha",    "~> 0.14.0"
-  s.add_development_dependency "minitest", "~> 4.2"
+  s.add_development_dependency "minitest", [">= 4.2", "< 6"]
   s.add_development_dependency "redis-store-testing"
 end


### PR DESCRIPTION
There are no known breaking changes between redis-store 1.2 and 1.3 (https://github.com/redis-store/redis-store/blob/master/CHANGELOG)