### PR TITLE
Assume semver

### DIFF
--- a/redis-rails.gemspec
+++ b/redis-rails.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "redis-store",         [">= 1.2.0", "< 1.4"]
-  s.add_dependency "redis-activesupport", "~> 5.0.0"
-  s.add_dependency "redis-actionpack",    "~> 5.0.0"
+  s.add_dependency "redis-activesupport", "~> 5.0"
+  s.add_dependency "redis-actionpack",    "~> 5.0"
 
   s.add_development_dependency "rake",     "~> 10"
   s.add_development_dependency "bundler",  "~> 1.3"


### PR DESCRIPTION
Assume that redis-activesupport and redis-actionpack follow semver, therefore the version constraint can be relaxed.