### PR TITLE
Use expire_after instead of expires_in for session_store in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ MyApplication::Application.config.session_store :redis_store, {
       namespace: "session"
     },
   ],
-  expires_in: 90.minutes
+  expire_after: 90.minutes
 }
 ```
 


### PR DESCRIPTION
Thank you for providing a great Gem!

`expires_in` is used for `session_store` in README#Usage. It does not seem to work.
Is'nt it mistaken with `expire_after`?

For Rails default `CookieStore`, we use `expire_after`.

Both `CookieStore` and `RedisStore` inherits [Rack::Session::Abstract::Persisted](https://github.com/rack/rack/blob/3d5c7d1919c51a988388ba95d2563c6003ec7ce3/lib/rack/session/abstract/id.rb#L200).
It has `expire_after` option but not `expires_in`.

Thanks.

