### PR TITLE
README: Use SVG for badge icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,9 @@ If you are on **Snow Leopard** you have to run `env ARCHFLAGS="-arch x86_64" bun
 
 ## Status
 
-[![Gem Version](https://badge.fury.io/rb/redis-rails.png)](http://badge.fury.io/rb/redis-rails)
-[![Build Status](https://secure.travis-ci.org/redis-store/redis-rails.png?branch=master)](http://travis-ci.org/redis-store/redis-rails?branch=master)
-[![Code Climate](https://codeclimate.com/github/redis-store/redis-rails.png)](https://codeclimate.com/github/redis-store/redis-rails)
+[![Gem Version](https://badge.fury.io/rb/redis-rails.svg)](http://badge.fury.io/rb/redis-rails)
+[![Build Status](https://secure.travis-ci.org/redis-store/redis-rails.svg?branch=master)](http://travis-ci.org/redis-store/redis-rails?branch=master)
+[![Code Climate](https://codeclimate.com/github/redis-store/redis-rails.svg)](https://codeclimate.com/github/redis-store/redis-rails)
 
 ## Copyright
 


### PR DESCRIPTION
This change has the build status badge icons render in shiny sparkly SVG.