### PR TITLE
Use expire_after instead of expires_in for session_store in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ config.session_store :redis_store, {
       namespace: "sessions"
     )
   ],
-  expires_in: 2.days
+  expire_after: 2.days
 }
 ```
 


### PR DESCRIPTION
Use expire_after instead of expires_in for session_store in "Usage with Redis Sentinel"

Please look at #64