### PR TITLE
Edited README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ MyApplication::Application.config.session_store :redis_store, {
   key: "_#{Rails.application.class.parent_name.downcase}_session"
 }
 ```
+(**NOTE:** You can not write `:expires_in` or `:expire_in`as a substitute for `:expire_after`.)
+
+For Rails default CookieStore, we use `:expire_after`.
+
+Both CookieStore and RedisStore inherits Rack::Session::Abstract::Persisted.
+It has `:expire_after` option but not `:expires_in`.
 
 And if you would like to use Redis as a rack-cache backend for HTTP caching, add [`redis-rack-cache`](https://github.com/redis-store/redis-rack-cache) to your Gemfile and add:
 


### PR DESCRIPTION
I wrote a note about `:expire_after` in the readme

I failed in this part when I used redis-rails as session store. So if you put this description in the README, I think other people will be saved