### PR TITLE
Begin sunsetting support for this gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 __`redis-rails`__ provides a full set of stores (*Cache*, *Session*, *HTTP Cache*) for __Ruby on Rails__. See the main [redis-store readme](https://github.com/redis-store/redis-store) for general guidelines.
 
+## A quick note about Rails 5.2
+
+Rails 5.2.0 [includes a Redis cache store out of the
+box](https://github.com/rails/rails/pull/31134), so you don't really
+need this gem anymore if you just need to store the fragment cache in
+Redis. Maintenence on the [redis-activesupport](https://github.com/redis-store/redis-activesupport) 
+gem will continue for security and compatibility issues, but we are no longer accepting new
+features. We are still actively maintaining all other gems in the redis-store
+family.
+
 ## Installation
 
 Add the following to your Gemfile:


### PR DESCRIPTION
When Rails 5.2 is released, we'll be notifying new users that this gem is unnecessary given an upgrade to the latest minor version of the framework. We'll be continuing to offer security/compatibility updates and bug fixes, but new feature development will cease on **redis-rails**, **redis-actionpack**, and **redis-activesupport**.

**NOTE:** All other redis-store gems will continue to be fully supported.