### PR TITLE
Add httponly to option run down for session storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ A brief run-down of these options...
   contents.
 - **secure** ensures HTTP cookies are transferred from server to client
   on a secure (HTTPS) connection
+- **httponly** ensures that all cookies have the HttpOnly flag set to true
 
 ### HTTP Caching
 


### PR DESCRIPTION
I noticed that this option was set in an initializer file but was not listed in the README. After some digging, I confirmed that [it is indeed a valid option](https://github.com/redis-store/redis-actionpack/blob/6c3af02a0b184651316cb89c3e563ee18d0f0389/lib/action_dispatch/middleware/session/redis_store.rb#L38) so I thought it would be good to add it to the options list. 

Let me know what you think! Thanks!