### PR TITLE
Remove s.rubyforge_project from .gemspec

### DIFF
--- a/redis-rails.gemspec
+++ b/redis-rails.gemspec
@@ -12,8 +12,6 @@ Gem::Specification.new do |s|
   s.description = %q{Redis for Ruby on Rails}
   s.license     = 'MIT'
 
-  s.rubyforge_project = "redis-rails"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
`Gem::Specification#rubyforge_project=` is deprecated with no replacement, so can be removed

Thanks for the tip @attenzione!