### PR TITLE
Replace deprecated parent_name with module_parent_name in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ use Redis as the session store.
 MyApplication::Application.config.session_store :redis_store,
   servers: ["redis://localhost:6379/0/session"],
   expire_after: 90.minutes,
-  key: "_#{Rails.application.class.parent_name.downcase}_session",
+  key: "_#{Rails.application.class.module_parent_name.downcase}_session",
   threadsafe: true,
   secure: true
 ```


### PR DESCRIPTION
The `parent_name` has been renamed to `module_parent_name` and is no longer accessible in Rails [v6.1.0](https://github.com/rails/rails/releases/tag/v6.1.0) and later versions.

To make it clearer for new users setting up the project, I have updated the documentation to use `module_parent_name`.